### PR TITLE
Custom OpenAI endpoints + Fixing HuggingFace custom endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/backends/outsource-lib/src/huggingface.rs
+++ b/backends/outsource-lib/src/huggingface.rs
@@ -8,8 +8,6 @@ use crate::{OutsourceError, Result};
 
 const DEFAULT_HUGGINGFACE_API_HOST: &str = "https://api-inference.huggingface.co";
 
-const CUSTOM_ENDPOINT_PREFIX: &str = "endpoint=";
-
 const MODELS_ENDPOINT: &str = "models/";
 
 const MAX_TOKENS_KEY: &str = "max_new_tokens";
@@ -36,12 +34,8 @@ pub async fn generate(
     model_description: ModelDescription,
     api_key: &str,
 ) -> Result<BackendGenerationResponse> {
-    let url = if model_description
-        .model_name
-        .starts_with(CUSTOM_ENDPOINT_PREFIX)
-    {
-        Url::parse(&model_description.model_name[CUSTOM_ENDPOINT_PREFIX.len()..])
-            .map_err(|_| OutsourceError::HostURLParse)?
+    let url = if model_description.endpoint.is_some() {
+        model_description.endpoint.unwrap()
     } else {
         Url::parse(DEFAULT_HUGGINGFACE_API_HOST)
             .expect("url should parse")

--- a/backends/outsource-lib/src/openai.rs
+++ b/backends/outsource-lib/src/openai.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use crate::util::check_status_code;
 use crate::{OutsourceError, Result};
 
-const OPENAI_API_HOST: &str = "https://api.openai.com";
+const DEFAULT_OPENAI_API_HOST: &str = "https://api.openai.com";
 
 const CHAT_COMPLETION_ENDPOINT: &str = "/v1/chat/completions";
 const COMPLETION_ENDPOINT: &str = "/v1/completions";
@@ -73,10 +73,14 @@ async fn send_generate_request(
     } else {
         COMPLETION_ENDPOINT
     };
-    let url = Url::parse(OPENAI_API_HOST)
-        .expect("url should parse")
-        .join(endpoint)
-        .unwrap();
+    let url = if model_description.endpoint.is_some() {
+        model_description.endpoint.unwrap().join(endpoint).unwrap()
+    } else {
+        Url::parse(DEFAULT_OPENAI_API_HOST)
+            .expect("url should parse")
+            .join(endpoint)
+            .unwrap()
+    };
 
     let mut body = request.model_parameters.take().unwrap_or_default();
 

--- a/backends/outsource/README.md
+++ b/backends/outsource/README.md
@@ -45,12 +45,12 @@ Run the backend executable to generate a configuration file at:
 |`stdio_server`|No|Stdio server settings. See [llmvm-protocol](https://github.com/djandries/llmvm/tree/master/protocol#stdio-server-configuration) for details.|
 |`http_server`|No|HTTP server settings. See [llmvm-protocol](https://github.com/djandries/llmvm/tree/master/protocol#http-server-configuration) for details.|
 
-### Hugging Face custom endpoints
+### Hugging Face and OpenAI custom endpoints
 
 Custom hosted endpoints may be used by supplying the prefix `endpoint=`, followed by the endpoint
 URL in the model name component of the model ID.
 
-For example, the model ID could be `outsource/huggingface-text/endpoint=https://yourendpointhere`.
+For example, the model ID could be `outsource/huggingface-text/endpoint=https://yourendpointhere` for HuggingFace, or `outsource/openai-chat/model_id/endpoint=https://yourendpointhere` for OpenAI.
 
 ## License
 

--- a/core-lib/src/generation.rs
+++ b/core-lib/src/generation.rs
@@ -8,7 +8,8 @@ use llmvm_protocol::{
 };
 use serde_json::Value;
 
-use tracing::{debug, info};
+use time::Error;
+use tracing::{debug, error, info};
 
 use crate::error::CoreError;
 use crate::presets::load_preset;
@@ -119,8 +120,9 @@ impl LLMVMCore {
         let model = parameters
             .model
             .ok_or(CoreError::MissingParameter("model"))?;
-        let model_description =
-            ModelDescription::from_str(&model).map_err(|_| CoreError::ModelDescriptionParse)?;
+        let model_description = ModelDescription::from_str(&model)
+            .map_err(|_| CoreError::ModelDescriptionParse)
+            .unwrap();
 
         let is_chat_model = model_description.is_chat_model();
         let prompt_parameters = parameters

--- a/core-lib/src/generation.rs
+++ b/core-lib/src/generation.rs
@@ -120,10 +120,8 @@ impl LLMVMCore {
         let model = parameters
             .model
             .ok_or(CoreError::MissingParameter("model"))?;
-        let model_description = ModelDescription::from_str(&model)
-            .map_err(|_| CoreError::ModelDescriptionParse)
-            .unwrap();
-
+        let model_description =
+            ModelDescription::from_str(&model).map_err(|_| CoreError::ModelDescriptionParse)?;
         let is_chat_model = model_description.is_chat_model();
         let prompt_parameters = parameters
             .prompt_parameters

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 multilink = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
+url = "2.3"
 
 [features]
 http-client = ["multilink/http-client"]


### PR DESCRIPTION
This PR allows to set OpenAI endpoints, and also fixes the "failed to parse model name" on HuggingFace when setting custom endpoints.

I slightly refactored the way that endpoints are handled so that we dont have to extract the URL for each time we create a new outsource model.

For OpenAI, setting custom endpoints has plenty of usecases, for example, [FastChat](https://github.com/lm-sys/FastChat) has the latest state of the art to run models quickly, and has a OpenAI compatible server, using this really fits in line with the idea of running your own coding assistant.

Possible todo is to refactor the code further and use the `url` crate (already present in your application) to extract keywords after the model name rather than hard-extracting the endpoint from the model name.

This also paves the way for data points outside of the endpoint if that is ever needed!

Also, this is my first PR here, I'm open for feedback.

Also, I noticed you are the dev behind Brave! I love the browser and what you're doing!